### PR TITLE
Export morphisms to JSON

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -75,6 +75,7 @@ Dependencies := rec(
   ],
   SuggestedOtherPackages := [
       [ "FunctorCategories", ">= 2023.07-01" ], # CategoryOfDecoratedQuivers
+      [ "json", "2.1.1" ], # Exporting to JSON
   ],
   ExternalConditions := [ ],
 ),

--- a/gap/CategoryOfZXDiagrams.gd
+++ b/gap/CategoryOfZXDiagrams.gd
@@ -50,6 +50,7 @@ CapJitAddTypeSignature( "VertexLabeledGraph", [ IsZXDiagramMorphism ], CapJitDat
 # helpers
 DeclareGlobalName( "ZX_LabelToInteger" );
 DeclareGlobalName( "ZX_IntegerToLabel" );
+DeclareGlobalName( "ZX_RemoveNeutralNodes" );
 DeclareGlobalName( "S_ZX_EDGES" );
 
 DeclareGlobalFunction( "SKELETAL_FIN_SETS_ExplicitCoequalizer_primitive_input" );

--- a/gap/CategoryOfZXDiagrams.gi
+++ b/gap/CategoryOfZXDiagrams.gi
@@ -92,113 +92,7 @@ CapJitAddTypeSignature( "ZX_IntegerToLabel", [ IsBigInt, IsList, IsList, IsBigIn
     
 end );
 
-BindGlobal( "S_ZX_EDGES", Immutable( [ [ 0, 0 ], [ 0, 1 ], [ 1, 0 ], [ 0, 2 ], [ 2, 0 ], [ 0, 3 ], [ 3, 0 ] ] ) );
-
-InstallGlobalFunction( CategoryOfZXDiagrams, function ( )
-  local ZX;
-    
-    if ValueOption( "no_precompiled_code" ) = true then
-        
-        if IsPackageMarkedForLoading( "FunctorCategories", ">= 2023.07-01" ) then
-            
-            ZX := CategoryOfZXDiagrams_as_CategoryOfCospans_CategoryOfDecoratedQuivers( : FinalizeCategory := false );
-            
-        else
-            
-            Error( "To get a version of `CategoryOfZXDiagrams` without precompiled code, the package `FunctorCategories` is required." );
-            
-        fi;
-        
-    else
-        
-        ZX := CreateCapCategoryWithDataTypes(
-            "Category of ZX-diagrams", IsCategoryOfZXDiagrams,
-            IsZXDiagramObject, IsZXDiagramMorphism, IsCapCategoryTwoCell,
-            IsBigInt, CapJitDataTypeOfNTupleOf( 2, CapJitDataTypeOfListOf( IsStringRep ), CapJitDataTypeOfListOf( CapJitDataTypeOfNTupleOf( 2, IsBigInt, IsBigInt ) ) ), fail
-            : is_computable := false
-        );
-        
-    fi;
-    
-    SetIsRigidSymmetricClosedMonoidalCategory( ZX, true );
-    
-    ##
-    AddDualOnObjects( ZX, function ( cat, obj )
-        
-        return obj;
-        
-    end );
-    
-    ##
-    AddEvaluationForDualWithGivenTensorProduct( ZX, function ( cat, source, obj, range )
-      local pair;
-        
-        #% CAP_JIT_DROP_NEXT_STATEMENT
-        Assert( 0, AsInteger( source ) = 2 * AsInteger( obj ) );
-        #% CAP_JIT_DROP_NEXT_STATEMENT
-        Assert( 0, AsInteger( range ) = 0 );
-        
-        pair := Pair( ListWithIdenticalEntries( AsInteger( source ), "input" ), List( [ 0 .. AsInteger( obj ) - 1 ], i -> [ i, AsInteger( source ) - 1 - i ] ) );
-        
-        return MorphismConstructor( cat, source, pair, range );
-        
-    end );
-    
-    ##
-    AddCoevaluationForDualWithGivenTensorProduct( ZX, function ( cat, source, obj, range )
-      local pair;
-        
-        #% CAP_JIT_DROP_NEXT_STATEMENT
-        Assert( 0, AsInteger( source ) = 0 );
-        #% CAP_JIT_DROP_NEXT_STATEMENT
-        Assert( 0, AsInteger( range ) = 2 * AsInteger( obj ) );
-        
-        pair := Pair( ListWithIdenticalEntries( AsInteger( range ), "output" ), List( [ 0 .. AsInteger( obj ) - 1 ], i -> [ i, AsInteger( range ) - 1 - i ] ) );
-        
-        return MorphismConstructor( cat, source, pair, range );
-        
-    end );
-    
-    if ValueOption( "no_precompiled_code" ) <> true then
-        
-        ADD_FUNCTIONS_FOR_CategoryOfZXDiagrams_precompiled( ZX );
-        
-    fi;
-    
-    Finalize( ZX );
-    
-    return ZX;
-    
-end );
-
-##
-InstallMethod( ViewString,
-        "for an object in a category of ZX-diagrams",
-        [ IsZXDiagramObject ],
-        
-  function ( obj )
-    
-    return Concatenation( "<An object in ", Name( CapCategory( obj ) ), " representing ", String( AsInteger( obj ) ), " input/output vertices>" );
-    
-end );
-
-##
-InstallMethod( DisplayString,
-        "for an object in a category of ZX-diagrams",
-        [ IsZXDiagramObject ],
-        
-  function ( obj )
-    
-    return Concatenation( "An object in ", Name( CapCategory( obj ) ), " representing ", String( AsInteger( obj ) ), " input/output vertices.\n" );
-    
-end );
-
-##
-InstallMethod( DisplayString,
-        "for a morphism in a category of ZX-diagrams",
-        [ IsZXDiagramMorphism ],
-        
-  function ( phi )
+BindGlobal( "ZX_RemoveNeutralNodes", function ( phi )
     local pair, labels, edges, pos, edge_positions, new_edge, edge_1, edge_2, remaining_indices;
     
     pair := MorphismDatum( phi );
@@ -309,6 +203,123 @@ InstallMethod( DisplayString,
         end );
         
     od;
+    
+    return [ labels, edges ];
+    
+end );
+
+BindGlobal( "S_ZX_EDGES", Immutable( [ [ 0, 0 ], [ 0, 1 ], [ 1, 0 ], [ 0, 2 ], [ 2, 0 ], [ 0, 3 ], [ 3, 0 ] ] ) );
+
+InstallGlobalFunction( CategoryOfZXDiagrams, function ( )
+  local ZX;
+    
+    if ValueOption( "no_precompiled_code" ) = true then
+        
+        if IsPackageMarkedForLoading( "FunctorCategories", ">= 2023.07-01" ) then
+            
+            ZX := CategoryOfZXDiagrams_as_CategoryOfCospans_CategoryOfDecoratedQuivers( : FinalizeCategory := false );
+            
+        else
+            
+            Error( "To get a version of `CategoryOfZXDiagrams` without precompiled code, the package `FunctorCategories` is required." );
+            
+        fi;
+        
+    else
+        
+        ZX := CreateCapCategoryWithDataTypes(
+            "Category of ZX-diagrams", IsCategoryOfZXDiagrams,
+            IsZXDiagramObject, IsZXDiagramMorphism, IsCapCategoryTwoCell,
+            IsBigInt, CapJitDataTypeOfNTupleOf( 2, CapJitDataTypeOfListOf( IsStringRep ), CapJitDataTypeOfListOf( CapJitDataTypeOfNTupleOf( 2, IsBigInt, IsBigInt ) ) ), fail
+            : is_computable := false
+        );
+        
+    fi;
+    
+    SetIsRigidSymmetricClosedMonoidalCategory( ZX, true );
+    
+    ##
+    AddDualOnObjects( ZX, function ( cat, obj )
+        
+        return obj;
+        
+    end );
+    
+    ##
+    AddEvaluationForDualWithGivenTensorProduct( ZX, function ( cat, source, obj, range )
+      local pair;
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, AsInteger( source ) = 2 * AsInteger( obj ) );
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, AsInteger( range ) = 0 );
+        
+        pair := Pair( ListWithIdenticalEntries( AsInteger( source ), "input" ), List( [ 0 .. AsInteger( obj ) - 1 ], i -> [ i, AsInteger( source ) - 1 - i ] ) );
+        
+        return MorphismConstructor( cat, source, pair, range );
+        
+    end );
+    
+    ##
+    AddCoevaluationForDualWithGivenTensorProduct( ZX, function ( cat, source, obj, range )
+      local pair;
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, AsInteger( source ) = 0 );
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, AsInteger( range ) = 2 * AsInteger( obj ) );
+        
+        pair := Pair( ListWithIdenticalEntries( AsInteger( range ), "output" ), List( [ 0 .. AsInteger( obj ) - 1 ], i -> [ i, AsInteger( range ) - 1 - i ] ) );
+        
+        return MorphismConstructor( cat, source, pair, range );
+        
+    end );
+    
+    if ValueOption( "no_precompiled_code" ) <> true then
+        
+        ADD_FUNCTIONS_FOR_CategoryOfZXDiagrams_precompiled( ZX );
+        
+    fi;
+    
+    Finalize( ZX );
+    
+    return ZX;
+    
+end );
+
+##
+InstallMethod( ViewString,
+        "for an object in a category of ZX-diagrams",
+        [ IsZXDiagramObject ],
+        
+  function ( obj )
+    
+    return Concatenation( "<An object in ", Name( CapCategory( obj ) ), " representing ", String( AsInteger( obj ) ), " input/output vertices>" );
+    
+end );
+
+##
+InstallMethod( DisplayString,
+        "for an object in a category of ZX-diagrams",
+        [ IsZXDiagramObject ],
+        
+  function ( obj )
+    
+    return Concatenation( "An object in ", Name( CapCategory( obj ) ), " representing ", String( AsInteger( obj ) ), " input/output vertices.\n" );
+    
+end );
+
+##
+InstallMethod( DisplayString,
+        "for a morphism in a category of ZX-diagrams",
+        [ IsZXDiagramMorphism ],
+        
+  function ( phi )
+    local phi_without_neutral_nodes, labels, edges;
+    
+    phi_without_neutral_nodes := ZX_RemoveNeutralNodes( phi );
+    labels := phi_without_neutral_nodes[1];
+    edges := phi_without_neutral_nodes[2];
     
     return Concatenation(
         "A morphism in ", Name( CapCategory( phi ) ), " given by a ZX diagram with ", String( Length( labels ) ), " vertex labels\n",

--- a/gap/Tools.gd
+++ b/gap/Tools.gd
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ZXCalculusForCAP: The category of ZX-diagrams
+#
+# Declarations
+#
+#! @Chapter Tools
+
+#! @Section Exporting ZX-diagrams
+
+#! @Description
+#!   Takes a morphism in a category of ZX-diagrams and a filename **file**
+#!   and exports the morphism as **file**.qgraph.
+#!   This function is only available if the package `json` is available.
+#!   See https://github.com/Quantomatic/quantomatic/blob/stable/docs/json_formats.txt
+#!   for an overview of the qgraph format.
+#! @Arguments morphism, filename
+DeclareGlobalFunction( "ExportAsQGraph" );

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ZXCalculusForCAP: The category of ZX-diagrams
+#
+# Implementations
+#
+
+if IsPackageMarkedForLoading( "json", "2.1.1" ) then
+
+  InstallGlobalFunction( ExportAsQGraph,
+    
+    function ( phi, filename )
+        local phi_without_neutral_nodes, labels, edges, wire_vertices,
+            node_vertices, pos, undir_edges, edge_counter, edge,
+            edge_name, qgraph, file;
+        
+        phi_without_neutral_nodes := ZX_RemoveNeutralNodes( phi );
+        
+        labels := phi_without_neutral_nodes[1];
+        edges := phi_without_neutral_nodes[2];
+        
+        wire_vertices := rec( );
+        node_vertices := rec( );
+        
+        # See https://github.com/Quantomatic/quantomatic/blob/stable/docs/json_formats.txt
+        # for a rough overview of the qgraph format.
+        
+        for pos in [ 1 .. Length( labels ) ] do
+        
+            if labels[pos] = "X" then
+            
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                                                data := rec( type := "X" ) );
+            
+            elif labels[pos] = "Z" then
+            
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                                                data := rec( type := "Z" ) );
+            
+            elif labels[pos] = "H" then
+            
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                                                data := rec( type := "hadamard" ) );
+            
+            elif labels[pos] = "input" then
+            
+                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
+                                                                   input := true,
+                                                                   output := false ) );
+            
+            elif labels[pos] = "output" then
+            
+                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
+                                                                   input := false,
+                                                                   output := true ) );
+            
+            elif labels[pos] = "input_output" then
+            
+                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
+                                                                   input := true,
+                                                                   output := true ) );
+            
+            else
+            
+                Error( "Unknown label." );
+            
+            fi;
+            
+        od;
+        
+        undir_edges := rec( );
+        
+        edge_counter := 0;
+        
+        for edge in edges do
+        
+            edge_name := Concatenation( "e", String( edge_counter ) );
+            
+            undir_edges.(edge_name) := rec( src := String( edge[1] ), tgt := String( edge[2] ) );
+            
+            edge_counter := edge_counter + 1;
+        
+        od;
+        
+        qgraph := rec( wire_vertices := wire_vertices,
+                       node_vertices := node_vertices,
+                       undir_edges := undir_edges );
+        
+        qgraph := GapToJsonString( qgraph );
+        
+        FileString( Concatenation( filename, ".qgraph" ), qgraph );
+        
+    end );
+
+fi;

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -73,7 +73,7 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
             
             edge := edges[edge_counter];
             
-            edge_name := Concatenation( "e", String( edge_counter ) );
+            edge_name := Concatenation( "e", String( edge_counter - 1 ) );
             
             undir_edges.(edge_name) := rec( src := String( edge[1] ), tgt := String( edge[2] ) );
             

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -53,17 +53,21 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
             elif labels[pos] = "H" then
                 
                 node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
-                                                data := rec( type := "hadamard" ) );
+                                                data := rec( type := "hadamard",
+                                                             is_edge := false,
+                                                             value := "\\pi" ) );
                 
             elif labels[pos] = "input" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, - pos ],
+                wire_vertices.(pos - 1) := rec( annotation := rec( boundary := true,
+                                                                   coord := [ 0, - pos ],
                                                                    input := true,
                                                                    output := false ) );
                 
             elif labels[pos] = "output" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 2, - pos ],
+                wire_vertices.(pos - 1) := rec( annotation := rec( boundary := true,
+                                                                   coord := [ 2, - pos ],
                                                                    input := false,
                                                                    output := true ) );
                 

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -25,44 +25,44 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         # for a rough overview of the qgraph format.
         
         for pos in [ 1 .. Length( labels ) ] do
-        
-            if labels[pos] = "X" then
             
+            if labels[pos] = "X" then
+                
                 node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
                                                 data := rec( type := "X" ) );
-            
+                
             elif labels[pos] = "Z" then
-            
+                
                 node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
                                                 data := rec( type := "Z" ) );
-            
+                
             elif labels[pos] = "H" then
-            
+                
                 node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
                                                 data := rec( type := "hadamard" ) );
-            
+                
             elif labels[pos] = "input" then
-            
+                
                 wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
                                                                    input := true,
                                                                    output := false ) );
-            
+                
             elif labels[pos] = "output" then
-            
+                
                 wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
                                                                    input := false,
                                                                    output := true ) );
-            
+                
             elif labels[pos] = "input_output" then
-            
+                
                 wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
                                                                    input := true,
                                                                    output := true ) );
-            
+                
             else
-            
+                
                 Error( "Unknown label." );
-            
+                
             fi;
             
         od;
@@ -72,13 +72,13 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         edge_counter := 0;
         
         for edge in edges do
-        
+            
             edge_name := Concatenation( "e", String( edge_counter ) );
             
             undir_edges.(edge_name) := rec( src := String( edge[1] ), tgt := String( edge[2] ) );
             
             edge_counter := edge_counter + 1;
-        
+            
         od;
         
         qgraph := rec( wire_vertices := wire_vertices,
@@ -90,5 +90,5 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         FileString( Concatenation( filename, ".qgraph" ), qgraph );
         
     end );
-
+    
 fi;

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -15,8 +15,22 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         
         phi_without_neutral_nodes := ZX_RemoveNeutralNodes( phi );
         
-        labels := phi_without_neutral_nodes[1];
-        edges := phi_without_neutral_nodes[2];
+        labels := ShallowCopy( phi_without_neutral_nodes[1] );
+        edges := ShallowCopy( phi_without_neutral_nodes[2] );
+        
+        # nodes which are simultaneously inputs and outputs are not supported by PyZX
+        # split input_output nodes into an input and an output node connected by an edge
+        for pos in [ 1 .. Length( labels ) ] do
+            
+            if labels[pos] = "input_output" then
+                
+                labels[pos] := "input";
+                Add( labels, "output" );
+                Add( edges, [ pos - 1, Length( labels ) - 1 ] );
+                
+            fi;
+            
+        od;
         
         wire_vertices := rec( );
         node_vertices := rec( );
@@ -28,35 +42,29 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
             
             if labels[pos] = "Z" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
                                                 data := rec( type := "Z" ) );
                 
             elif labels[pos] = "X" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
                                                 data := rec( type := "X" ) );
                 
             elif labels[pos] = "H" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
                                                 data := rec( type := "hadamard" ) );
                 
             elif labels[pos] = "input" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
+                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, - pos ],
                                                                    input := true,
                                                                    output := false ) );
                 
             elif labels[pos] = "output" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
+                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 2, - pos ],
                                                                    input := false,
-                                                                   output := true ) );
-                
-            elif labels[pos] = "input_output" then
-                
-                wire_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ],
-                                                                   input := true,
                                                                    output := true ) );
                 
             else

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -69,15 +69,13 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         
         undir_edges := rec( );
         
-        edge_counter := 0;
-        
-        for edge in edges do
+        for edge_counter in [ 1 .. Length( edges ) ] do
+            
+            edge := edges[edge_counter];
             
             edge_name := Concatenation( "e", String( edge_counter ) );
             
             undir_edges.(edge_name) := rec( src := String( edge[1] ), tgt := String( edge[2] ) );
-            
-            edge_counter := edge_counter + 1;
             
         od;
         

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -26,15 +26,15 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         
         for pos in [ 1 .. Length( labels ) ] do
             
-            if labels[pos] = "X" then
-                
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
-                                                data := rec( type := "X" ) );
-                
-            elif labels[pos] = "Z" then
+            if labels[pos] = "Z" then
                 
                 node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
                                                 data := rec( type := "Z" ) );
+                
+            elif labels[pos] = "X" then
+                
+                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 0, 0 ] ),
+                                                data := rec( type := "X" ) );
                 
             elif labels[pos] = "H" then
                 

--- a/init.g
+++ b/init.g
@@ -9,3 +9,5 @@ ReadPackage( "ZXCalculusForCAP", "gap/CategoryOfCospans_for_ZXCalculus.gd" );
 ReadPackage( "ZXCalculusForCAP", "gap/CategoryOfZXDiagrams.gd" );
 
 ReadPackage( "ZXCalculusForCAP", "gap/CategoryOfZXDiagrams_as_CategoryOfCospans_CategoryOfDecoratedQuivers.gd" );
+
+ReadPackage( "ZXCalculusForCAP", "gap/Tools.gd" );

--- a/read.g
+++ b/read.g
@@ -10,6 +10,8 @@ ReadPackage( "ZXCalculusForCAP", "gap/precompiled_categories/CategoryOfZXDiagram
 
 ReadPackage( "ZXCalculusForCAP", "gap/CategoryOfZXDiagrams.gi" );
 
+ReadPackage( "ZXCalculusForCAP", "gap/Tools.gi" );
+
 #= comment for Julia
 if IsPackageMarkedForLoading( "FunctorCategories", ">= 2023.07-01" ) then
     

--- a/tst/100_LoadPackage.tst
+++ b/tst/100_LoadPackage.tst
@@ -13,6 +13,8 @@ gap> LoadPackage( "FreydCategoriesForCAP", false );
 true
 gap> LoadPackage( "FunctorCategories", false );
 true
+gap> LoadPackage( "json", false );
+true
 gap> LoadPackage( "ZXCalculusForCAP", false );
 true
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
@@ -21,6 +23,8 @@ true
 gap> LoadPackage( "FreydCategoriesForCAP" );
 true
 gap> LoadPackage( "FunctorCategories" );
+true
+gap> LoadPackage( "json" );
 true
 gap> LoadPackage( "ZXCalculusForCAP" );
 true

--- a/tst/CategoryOfZXDiagrams.tst
+++ b/tst/CategoryOfZXDiagrams.tst
@@ -45,11 +45,6 @@ els
   [ [ 0, 5 ], [ 1, 4 ], [ 2, 3 ], [ 6, 11 ], [ 7, 10 ], [ 8, 9 ] ].
 
 #
-gap> Double_edge := MorphismConstructor( one, [ [ "input", "output" ], [ [ BigInt( 0 ), BigInt( 1 ) ], [ BigInt( 0 ), BigInt( 1 ) ] ] ], one );;
-gap> IsWellDefinedForMorphisms( Double_edge );
-true
-
-#
 gap> X_1_1 := MorphismConstructor( one, [ [ "input", "X", "output" ], [ [ BigInt( 0 ), BigInt( 1 ) ], [ BigInt( 1 ), BigInt( 2 ) ] ] ], one );;
 gap> IsWellDefinedForMorphisms( X_1_1 );
 true

--- a/tst/CategoryOfZXDiagrams.tst
+++ b/tst/CategoryOfZXDiagrams.tst
@@ -60,4 +60,14 @@ gap> IsWellDefinedForMorphisms( H );
 true
 
 #
+gap> X_1_2 := MorphismConstructor( one, [ [ "input", "X", "output", "output" ], [ [ BigInt( 0 ), BigInt( 1 ) ], [ BigInt( 1 ), BigInt( 2 ) ], [ BigInt( 1 ), BigInt( 3 ) ] ] ], two );;
+gap> IsWellDefinedForMorphisms( X_1_2 );
+true
+
+#
+gap> Z_2_1 := MorphismConstructor( two, [ [ "input", "input", "Z", "output" ], [ [ BigInt( 0 ), BigInt( 2 ) ], [ BigInt( 1 ), BigInt( 2 ) ], [ BigInt( 2 ), BigInt( 3 ) ] ] ], one );;
+gap> IsWellDefinedForMorphisms( Z_2_1 );
+true
+
+#
 gap> STOP_TEST( "CategoryOfZXDiagrams" );

--- a/tst/CategoryOfZXDiagrams.tst
+++ b/tst/CategoryOfZXDiagrams.tst
@@ -45,6 +45,11 @@ els
   [ [ 0, 5 ], [ 1, 4 ], [ 2, 3 ], [ 6, 11 ], [ 7, 10 ], [ 8, 9 ] ].
 
 #
+gap> Double_edge := MorphismConstructor( one, [ [ "input", "output" ], [ [ BigInt( 0 ), BigInt( 1 ) ], [ BigInt( 0 ), BigInt( 1 ) ] ] ], one );;
+gap> IsWellDefinedForMorphisms( Double_edge );
+true
+
+#
 gap> X_1_1 := MorphismConstructor( one, [ [ "input", "X", "output" ], [ [ BigInt( 0 ), BigInt( 1 ) ], [ BigInt( 1 ), BigInt( 2 ) ] ] ], one );;
 gap> IsWellDefinedForMorphisms( X_1_1 );
 true

--- a/tst/CategoryOfZXDiagrams_export.tst
+++ b/tst/CategoryOfZXDiagrams_export.tst
@@ -1,0 +1,15 @@
+gap> START_TEST( "CategoryOfZXDiagrams_export" );
+
+#
+# test ExportAsQGraph
+gap> tmp_dir := DirectoryTemporary( );;
+gap> ExportAsQGraph( id, Filename( tmp_dir, "id" ) );
+gap> ExportAsQGraph( ev, Filename( tmp_dir, "ev" ) );
+gap> ExportAsQGraph( coev, Filename( tmp_dir, "coev" ) );
+gap> ExportAsQGraph( X_1_1, Filename( tmp_dir, "X_1_1" ) );
+gap> ExportAsQGraph( Z_1_1, Filename( tmp_dir, "Z_1_1" ) );
+gap> ExportAsQGraph( H, Filename( tmp_dir, "H" ) );
+gap> ExportAsQGraph( PreCompose( X_1_2, Z_2_1 ), Filename( tmp_dir, "X_1_2_Z_2_1" ) );
+
+#
+gap> STOP_TEST( "CategoryOfZXDiagrams_export" );


### PR DESCRIPTION
This is very rudimentary right now.

A problem is, that the annotations in the JSON format are not optional:
https://github.com/Quantomatic/pyzx/blob/18e0a4d3004f5972afcb4a33de7d325df6c539f7/pyzx/graph/jsonparser.py#L62
(Even though it's stated in their documentation to be optional, it's probably too old...)

And this is a reason for failure:
```gap
gap tst/CategoryOfZXDiagrams.tst 

gap> ExportAsQGraph( H, "H" );
```

Produces a file `H.qgraph`:

```json
{
  "node_vertices": {
    "0": {
      "data": {
        "type": "input"
      }
    },
    "1": {
      "data": {
        "type": "H"
      }
    },
    "2": {
      "data": {
        "type": "output"
      }
    }
  },
  "undir_edges": {
    "E01": {
      "src": 0,
      "tgt": 1
    },
    "E12": {
      "src": 1,
      "tgt": 2
    }
  }
}
```
Trying to load it in Python:

```python
>>> import pyzx as zx
>>> with open("H.qgraph") as file:
...     json = file.read()
... 
>>> zx.Graph.from_json(json)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tom/Software/Python/lib/python3.11/site-packages/pyzx/graph/base.py", line 474, in from_json
    return json_to_graph(js,cls.backend)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/Software/Python/lib/python3.11/site-packages/pyzx/graph/jsonparser.py", line 62, in json_to_graph
    c = attr['annotation']['coord']
        ~~~~^^^^^^^^^^^^^^
KeyError: 'annotation'

```
I have not tested setting the annotations to a fixed value (or something else), because I don't know if this is even desirable.
Also, I barely understand the various node/vertex types and which ones have to be chosen for the JSON. Right now, I'm only making a guess from examples I've found.

We have to talk about this in person next week, I would rather not have to dig through the ZX-Calculus, because that likely takes too much time.