### PR TITLE
Make vertex names in JSON export more closely match PyZX format

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ZXCalculusForCAP",
 Subtitle := "The category of ZX-diagrams",
-Version := "2023.10-02",
+Version := "2023.10-03",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -9,9 +9,7 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
   InstallGlobalFunction( ExportAsQGraph,
     
     function ( phi, filename )
-        local phi_without_neutral_nodes, labels, edges, wire_vertices,
-            node_vertices, pos, undir_edges, edge_counter, edge,
-            edge_name, qgraph, file;
+      local phi_without_neutral_nodes, labels, edges, wire_vertices, node_vertices, vertex_names, padding_length, get_vertex_name, vertex_name, undir_edges, edge, edge_name, src_vertex_name, tgt_vertex_name, qgraph, pos, edge_counter;
         
         phi_without_neutral_nodes := ZX_RemoveNeutralNodes( phi );
         
@@ -35,6 +33,27 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         wire_vertices := rec( );
         node_vertices := rec( );
         
+        vertex_names := [ ];
+        
+        # we want to pad all numbers with zeros on the left so the order does not change when ordering them as strings
+        # this helps to work around https://github.com/Quantomatic/pyzx/issues/168
+        padding_length := Int( Log10( Float( Length( labels ) ) ) ) + 1;
+        
+        get_vertex_name := function ( prefix, record )
+          local id, id_string, vertex_name;
+            
+            id := Length( RecNames( record ) );
+            
+            id_string := String( id, padding_length );
+            
+            vertex_name := Concatenation( prefix, ReplacedString( id_string, " ", "0" ) );
+            
+            Assert( 0, not IsBound( record.(vertex_name) ) );
+            
+            return vertex_name;
+            
+        end;
+        
         # See https://github.com/Quantomatic/quantomatic/blob/stable/docs/json_formats.txt
         # for a rough overview of the qgraph format.
         
@@ -42,35 +61,72 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
             
             if labels[pos] = "Z" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
-                                                data := rec( type := "Z" ) );
+                vertex_name := get_vertex_name( "v", node_vertices );
+                
+                node_vertices.(vertex_name) := rec(
+                    annotation := rec(
+                        coord := [ 1, - pos ],
+                    ),
+                    data := rec(
+                        type := "Z",
+                    )
+                );
                 
             elif labels[pos] = "X" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
-                                                data := rec( type := "X" ) );
+                vertex_name := get_vertex_name( "v", node_vertices );
+                
+                node_vertices.(vertex_name) := rec(
+                    annotation := rec(
+                        coord := [ 1, - pos ],
+                    ),
+                    data := rec(
+                        type := "X",
+                    )
+                );
+                
                 
             elif labels[pos] = "H" then
                 
-                node_vertices.(pos - 1) := rec( annotation := rec( coord := [ 1, - pos ] ),
-                                                data := rec( type := "hadamard",
-                                                             # always use Hadamard edges to work around https://github.com/Quantomatic/pyzx/issues/161
-                                                             is_edge := "true",
-                                                             value := "\\pi" ) );
+                vertex_name := get_vertex_name( "v", node_vertices );
+                
+                node_vertices.(vertex_name) := rec(
+                    annotation := rec(
+                        coord := [ 1, - pos ],
+                    ),
+                    data := rec(
+                        type := "hadamard",
+                        # always use Hadamard edges to work around https://github.com/Quantomatic/pyzx/issues/161
+                        is_edge := "true",
+                        value := "\\pi",
+                    ),
+                );
                 
             elif labels[pos] = "input" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( boundary := true,
-                                                                   coord := [ 0, - pos ],
-                                                                   input := true,
-                                                                   output := false ) );
+                vertex_name := get_vertex_name( "b", wire_vertices );
+                
+                wire_vertices.(vertex_name) := rec(
+                    annotation := rec(
+                        boundary := true,
+                        coord := [ 0, - pos ],
+                        input := true,
+                        output := false,
+                    ),
+                );
                 
             elif labels[pos] = "output" then
                 
-                wire_vertices.(pos - 1) := rec( annotation := rec( boundary := true,
-                                                                   coord := [ 2, - pos ],
-                                                                   input := false,
-                                                                   output := true ) );
+                vertex_name := get_vertex_name( "b", wire_vertices );
+                
+                wire_vertices.(vertex_name) := rec(
+                    annotation := rec(
+                        boundary := true,
+                        coord := [ 2, - pos ],
+                        input := false,
+                        output := true,
+                    ),
+                );
                 
             else
                 
@@ -78,7 +134,12 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
                 
             fi;
             
+            Assert( 0, Length( vertex_names ) = pos - 1 );
+            Add( vertex_names, vertex_name );
+            
         od;
+        
+        Assert( 0, Length( vertex_names ) = Length( labels ) );
         
         undir_edges := rec( );
         
@@ -88,7 +149,10 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
             
             edge_name := Concatenation( "e", String( edge_counter - 1 ) );
             
-            undir_edges.(edge_name) := rec( src := String( edge[1] ), tgt := String( edge[2] ) );
+            src_vertex_name := vertex_names[edge[1] + 1];
+            tgt_vertex_name := vertex_names[edge[2] + 1];
+            
+            undir_edges.(edge_name) := rec( src := src_vertex_name, tgt := tgt_vertex_name );
             
         od;
         


### PR DESCRIPTION
This helps working around another undocumented assumption in PyZX.