### PR TITLE
preload FinSetsForCAP before FreydCategoriesForCAP in tests

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ZXCalculusForCAP",
 Subtitle := "The category of ZX-diagrams",
-Version := "2023.11-01",
+Version := "2023.11-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/tst/100_LoadPackage.tst
+++ b/tst/100_LoadPackage.tst
@@ -7,7 +7,7 @@
 gap> PushOptions( rec( OnlyNeeded := true ) );
 gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
-gap> LoadPackage( "Toposes", false );
+gap> LoadPackage( "FinSetsForCAP", false );
 true
 gap> LoadPackage( "FreydCategoriesForCAP", false );
 true
@@ -18,7 +18,7 @@ true
 gap> LoadPackage( "ZXCalculusForCAP", false );
 true
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
-gap> LoadPackage( "Toposes" );
+gap> LoadPackage( "FinSetsForCAP" );
 true
 gap> LoadPackage( "FreydCategoriesForCAP" );
 true


### PR DESCRIPTION
to have the full functionality of FreydCategoriesForCAP (e.g., linear closure categories) and bump Version to V2023.11-02