### PR TITLE
Do not hardcode the `.qgraph` file extension

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ZXCalculusForCAP",
 Subtitle := "The category of ZX-diagrams",
-Version := "2024.04-02",
+Version := "2024.06-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/gap/Tools.gd
+++ b/gap/Tools.gd
@@ -19,7 +19,7 @@ DeclareGlobalFunction( "ExportAsQGraphString" );
 
 #! @Description
 #!   Takes a morphism in a category of ZX-diagrams and a filename **file**
-#!   and exports the morphism as **file**.qgraph.
+#!   and exports the morphism to **file**.
 #!   This function is only available if the package `json` is available.
 #!   See https://github.com/Quantomatic/quantomatic/blob/stable/docs/json_formats.txt
 #!   for an overview of the qgraph format.
@@ -38,7 +38,7 @@ DeclareGlobalFunction( "ImportFromQGraphString" );
 
 #! @Description
 #!   Takes a category of ZX-diagrams and a filename **file**
-#!   and imports the ZX-diagram in **file**.qgraph as a morphism.
+#!   and imports the ZX-diagram in **file** as a morphism.
 #!   This function is only available if the package `json` is available.
 #!   See https://github.com/Quantomatic/quantomatic/blob/stable/docs/json_formats.txt
 #!   for an overview of the qgraph format.

--- a/gap/Tools.gi
+++ b/gap/Tools.gi
@@ -263,7 +263,7 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
         
         qgraph := ExportAsQGraphString( phi );
         
-        FileString( Concatenation( filename, ".qgraph" ), qgraph );
+        FileString( filename, qgraph );
         
     end );
     
@@ -488,7 +488,7 @@ if IsPackageMarkedForLoading( "json", "2.1.1" ) then
       function ( cat, filename )
         local qgraph;
         
-        qgraph := StringFile( Concatenation( filename, ".qgraph" ) );
+        qgraph := StringFile( filename );
         
         Assert( 0, qgraph <> fail );
         


### PR DESCRIPTION
ZXLive uses `.json`