### PR TITLE
Use gap_to_julia in test-gap_to_julia

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ZXCalculusForCAP",
 Subtitle := "The category of ZX-diagrams",
-Version := "2025.06-08",
+Version := "2025.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ test-spacing:
 test-gap_to_julia: doc
 	if [ -d "../FinSetsForCAP" ]; then make -C "../FinSetsForCAP" doc; fi
 	git clone https://github.com/homalg-project/CAP_project.jl.git ~/.julia/dev/CAP_project.jl
-	sh -c "cd ~/.julia/dev/CAP_project.jl && export PATH="~/.julia/dev/CAP_project.jl/gap_to_julia:$$PATH" && make -C CAP clean-gen && make -C MonoidalCategories clean-gen && make -C CartesianCategories clean-gen && make -C Toposes clean-gen && make -C FinSetsForCAP clean-gen && make -C ZXCalculusForCAP clean-gen"
+	sh -c "cd ~/.julia/dev/CAP_project.jl && export PATH="~/.julia/dev/CAP_project.jl/gap_to_julia:$$PATH" && gap_to_julia CAP && gap_to_julia MonoidalCategories && gap_to_julia CartesianCategories && gap_to_julia Toposes && gap_to_julia FinSetsForCAP && gap_to_julia ZXCalculusForCAP"
 	julia -e 'using Pkg; Pkg.develop(path = "/home/gap/.julia/dev/CAP_project.jl/CAP");'
 	julia -e 'using Pkg; Pkg.develop(path = "/home/gap/.julia/dev/CAP_project.jl/MonoidalCategories");'
 	julia -e 'using Pkg; Pkg.develop(path = "/home/gap/.julia/dev/CAP_project.jl/CartesianCategories");'


### PR DESCRIPTION
Replace clean-gen make calls with gap_to_julia for CAP, MonoidalCategories, CartesianCategories, Toposes, FinSetsForCAP, and ZXCalculusForCAP.

Bump version to V2025.08-01